### PR TITLE
Add generateId utility

### DIFF
--- a/geo-convert/src/main.ts
+++ b/geo-convert/src/main.ts
@@ -4,6 +4,7 @@ import {
   convertWGS84toUTM,
   parseUTMInputs,
 } from "./converters";
+import { generateId } from "./utils/generateId";
 import type {
   ConversionRecord,
   UTMCoordinate,
@@ -155,7 +156,7 @@ function addToHistory(
   output: WGS84Coordinate | UTMCoordinate
 ): void {
   const record: ConversionRecord = {
-    id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
+    id: generateId(),
     timestamp: new Date(),
     type,
     input,

--- a/geo-convert/src/utils/generateId/generateId.spec.ts
+++ b/geo-convert/src/utils/generateId/generateId.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { generateId } from "./generateId";
+
+describe("generateId", () => {
+  it("should produce unique identifiers", () => {
+    const id1 = generateId();
+    const id2 = generateId();
+    expect(id1).not.toBe(id2);
+  });
+
+  it("should return a non-empty string", () => {
+    const id = generateId();
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+  });
+});

--- a/geo-convert/src/utils/generateId/generateId.ts
+++ b/geo-convert/src/utils/generateId/generateId.ts
@@ -1,0 +1,8 @@
+/**
+ * Generate a unique identifier for conversion history records.
+ *
+ * The identifier ensures each stored record can be reliably referenced.
+ */
+export const generateId = (): string => {
+  return Date.now().toString() + Math.random().toString(36).slice(2, 11);
+};

--- a/geo-convert/src/utils/generateId/index.ts
+++ b/geo-convert/src/utils/generateId/index.ts
@@ -1,0 +1,1 @@
+export * from './generateId';


### PR DESCRIPTION
## Summary
- add a `generateId` util module with tests
- use `generateId` when creating history items

## Testing
- `pnpm test:run`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6859c0d7b05c833281fa84efbf1b1703