### PR TITLE
Add i18n for history buttons

### DIFF
--- a/geo-convert/src/i18n/en.json
+++ b/geo-convert/src/i18n/en.json
@@ -7,5 +7,7 @@
   "convert": "Convert",
   "result": "Result",
   "invalidInput": "Invalid input",
-  "conversionError": "Conversion error"
+  "conversionError": "Conversion error",
+  "clearHistory": "Clear History",
+  "exportHistory": "Export History"
 }

--- a/geo-convert/src/i18n/he.json
+++ b/geo-convert/src/i18n/he.json
@@ -7,5 +7,7 @@
   "convert": "המר",
   "result": "תוצאה",
   "invalidInput": "קלט לא תקין",
-  "conversionError": "שגיאה בהמרה"
+  "conversionError": "שגיאה בהמרה",
+  "clearHistory": "נקה היסטוריה",
+  "exportHistory": "ייצא היסטוריה"
 }

--- a/geo-convert/src/main.ts
+++ b/geo-convert/src/main.ts
@@ -121,8 +121,8 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
         <div class="bg-white/[0.03] rounded-lg p-4 md:p-6 border border-white/10 min-w-0 w-full box-border history-section">
           <h3>Conversion History (<span id="history-count">0</span>)</h3>
           <div class="history-controls">
-            <button id="clear-history" class="clear-button">Clear History</button>
-            <button id="export-history" class="export-button">Export History</button>
+            <button id="clear-history" class="clear-button" data-i18n="clearHistory">Clear History</button>
+            <button id="export-history" class="export-button" data-i18n="exportHistory">Export History</button>
           </div>
           <div id="history-list" class="history-list">
             <div class="history-empty">No conversions yet</div>


### PR DESCRIPTION
## Summary
- add new English and Hebrew translations for history buttons
- wire up the Clear History and Export History buttons to i18n

## Testing
- `pnpm format` *(fails: command not found)*
- `pnpm lint` *(fails: command not found)*
- `pnpm test` *(fails: vitest not installed)*
- `pnpm build` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ce8e28188332a405cdc9a9926cb0