### PR TITLE
Add e2e for WGS input

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:4173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -71,9 +71,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'pnpm --dir ../geo-convert build && pnpm --dir ../geo-convert preview --port 4173',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/e2e/tests/convert-wgs-to-utm.spec.ts
+++ b/e2e/tests/convert-wgs-to-utm.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { GeoConvertPage } from './pageObjects/GeoConvertPage';
+
+test.describe('WGS to UTM conversion', () => {
+  test('should convert 32.062289, 34.772015 to 35s e:667272.250 n:3548711.126', async ({ page }) => {
+    const geoPage = new GeoConvertPage(page);
+    await geoPage.goto();
+    await geoPage.enterWGS('32.062289', '34.772015');
+    await geoPage.convertToUTM();
+
+    const { zone, hemisphere, easting, northing } = await geoPage.getUTMValues();
+
+    expect(`${zone}${hemisphere.toLowerCase()}`).toBe('35s');
+    expect(parseFloat(easting)).toBeCloseTo(667272.25, 2);
+    expect(parseFloat(northing)).toBeCloseTo(3548711.126, 3);
+  });
+});

--- a/e2e/tests/pageObjects/GeoConvertPage.ts
+++ b/e2e/tests/pageObjects/GeoConvertPage.ts
@@ -1,0 +1,31 @@
+import { Page } from '@playwright/test';
+
+export class GeoConvertPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/');
+  }
+
+  async enterWGS(lat: string, lon: string): Promise<void> {
+    await this.page.fill('#latitude-input', lat);
+    await this.page.fill('#longitude-input', lon);
+  }
+
+  async convertToUTM(): Promise<void> {
+    await this.page.click('#convert-to-utm');
+  }
+
+  async getUTMValues(): Promise<{ zone: string; hemisphere: string; easting: string; northing: string }>
+  {
+    const easting = await this.page.inputValue('#easting-input');
+    const northing = await this.page.inputValue('#northing-input');
+    const zone = await this.page.inputValue('#zone-input');
+    const hemisphere = await this.page.inputValue('#hemisphere-select');
+    return { zone, hemisphere, easting, northing };
+  }
+}


### PR DESCRIPTION
## Summary
- add Playwright page object and spec for coordinate conversion
- run e2e through Playwright config with local preview server

## Testing
- `pnpm -r --if-present run test`
- `pnpm -r --if-present run build`
- `npx playwright test` *(fails: Expected "35s" but received "36n")*


------
https://chatgpt.com/codex/tasks/task_e_6859dafdd914833283d1cabe8eae9623