### PR TITLE
Remove confirmation dialog when deleting history

### DIFF
--- a/geo-convert/src/main.ts
+++ b/geo-convert/src/main.ts
@@ -442,16 +442,10 @@ function deleteHistoryItem(id: string): void {
   const record = conversionHistory.find((r) => r.id === id);
   if (!record) return;
 
-  const confirmMessage = record.title
-    ? `Are you sure you want to delete "${record.title}"?`
-    : "Are you sure you want to delete this conversion?";
-
-  if (confirm(confirmMessage)) {
-    conversionHistory = conversionHistory.filter((r) => r.id !== id);
-    saveHistory();
-    updateHistoryDisplay();
-    notyf.success(`✓ ${t("conversionDeleted")}`);
-  }
+  conversionHistory = conversionHistory.filter((r) => r.id !== id);
+  saveHistory();
+  updateHistoryDisplay();
+  notyf.success(`✓ ${t("conversionDeleted")}`);
 }
 
 // Clear history


### PR DESCRIPTION
## Summary
- delete history items without confirmation

## Testing
- `pnpm run lint` *(fails: Missing script)*
- `pnpm run format` *(fails: Missing script)*
- `pnpm run test` *(fails: 1 failing test)*
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859e58ccb488332970878d1ffd9da5a