### PR TITLE
Add history validation to e2e conversion

### DIFF
--- a/e2e/tests/convert-wgs-to-utm.spec.ts
+++ b/e2e/tests/convert-wgs-to-utm.spec.ts
@@ -16,5 +16,8 @@ test.describe("WGS to UTM conversion", () => {
     expect(`${zone}${hemisphere.toLowerCase()}`).toBe("36n");
     expect(parseFloat(easting)).toBeCloseTo(667274.762, 2);
     expect(parseFloat(northing)).toBeCloseTo(3548713.386, 2);
+
+    const historyCount = await geoPage.getHistoryCount();
+    expect(historyCount).toBeGreaterThan(0);
   });
 });

--- a/e2e/tests/pageObjects/GeoConvertPage.ts
+++ b/e2e/tests/pageObjects/GeoConvertPage.ts
@@ -28,4 +28,9 @@ export class GeoConvertPage {
     const hemisphere = await this.page.inputValue('#hemisphere-select');
     return { zone, hemisphere, easting, northing };
   }
+
+  async getHistoryCount(): Promise<number> {
+    const countText = await this.page.textContent('#history-count');
+    return parseInt(countText ?? '0', 10);
+  }
 }


### PR DESCRIPTION
## Summary
- add a helper for history count to GeoConvert page object
- check that the conversion is stored in history in the e2e test

## Testing
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6859ee70fde8833290e799989f240e6e