### PR TITLE
Refactor info modal styling to Tailwind

### DIFF
--- a/geo-convert/src/components/infoButton/infoButton.ts
+++ b/geo-convert/src/components/infoButton/infoButton.ts
@@ -23,7 +23,8 @@ export const createInfoButton = (): HTMLButtonElement => {
  */
 const showInfoDialog = (): void => {
   const modal = document.createElement("div");
-  modal.className = "info-modal";
+  modal.className =
+    "info-modal fixed inset-0 bg-black/70 flex items-center justify-center z-[1000] p-4 box-border";
   modal.innerHTML = `
     <div class="info-dialog">
       <p>${t("infoDialogMessage", { phone: getPhone() })}</p>

--- a/geo-convert/src/style.css
+++ b/geo-convert/src/style.css
@@ -693,20 +693,6 @@ button:active {
 }
 
 /* Info Modal */
-.info-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1rem;
-  box-sizing: border-box;
-}
 
 .info-dialog {
   background: linear-gradient(135deg, #1e293b, #334155);


### PR DESCRIPTION
## Summary
- use Tailwind classes for `.info-modal`
- remove obsolete `.info-modal` CSS rules

## Testing
- `pnpm test`
- `pnpm build`
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859edd30d188332bc26c31f1b8ecd3d