### PR TITLE
Add CSV e2e test

### DIFF
--- a/e2e/tests/csv-import.spec.ts
+++ b/e2e/tests/csv-import.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { GeoConvertPage } from "./pageObjects/GeoConvertPage";
+import path from "path";
+
+test.describe("CSV import", () => {
+  test("should process sample csv and add rows to history", async ({ page }) => {
+    const geoPage = new GeoConvertPage(page);
+    const csvPath = path.resolve(__dirname, "../../geo-convert/examp.csv");
+
+    await geoPage.goto();
+    await geoPage.uploadCSV(csvPath);
+    await geoPage.confirmCSVImport();
+    await geoPage.cancelCSVDownload();
+
+    await expect(await geoPage.historyCount()).toBe(5);
+    await expect(page.locator("#history-list .history-header")).toHaveCount(5);
+
+  });
+});

--- a/e2e/tests/pageObjects/GeoConvertPage.ts
+++ b/e2e/tests/pageObjects/GeoConvertPage.ts
@@ -28,4 +28,21 @@ export class GeoConvertPage {
     const hemisphere = await this.page.inputValue('#hemisphere-select');
     return { zone, hemisphere, easting, northing };
   }
+
+  async uploadCSV(filePath: string): Promise<void> {
+    await this.page.setInputFiles('#csv-file-input', filePath);
+  }
+
+  async confirmCSVImport(): Promise<void> {
+    await this.page.click('#confirm-csv-import');
+  }
+
+  async cancelCSVDownload(): Promise<void> {
+    await this.page.click('#cancel-csv-download');
+  }
+
+  async historyCount(): Promise<number> {
+    const count = await this.page.textContent('#history-count');
+    return parseInt(count || '0', 10);
+  }
 }


### PR DESCRIPTION
## Summary
- extend GeoConvertPage with CSV helpers
- add e2e test for CSV import

## Testing
- `pnpm --dir geo-convert test`
- `pnpm --dir geo-convert build`
- `pnpm --dir e2e e2e`


------
https://chatgpt.com/codex/tasks/task_e_6859ec9189288332b2afe44af0ea6c62