### PR TITLE
use zod for UTM input validation

### DIFF
--- a/geo-convert/src/converters/parseUTMInputs/index.ts
+++ b/geo-convert/src/converters/parseUTMInputs/index.ts
@@ -1,1 +1,1 @@
-export * from './parseUTMInputs'
+export * from "./parseUTMInputs";


### PR DESCRIPTION
## Summary
- validate UTM input parsing with a zod schema
- fix barrel export formatting

## Testing
- `pnpm test`
- `pnpm build`
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm lint` *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f6abed1883328180a6e21f0c5b3b