### PR TITLE
Add manual CSV mapping e2e test

### DIFF
--- a/e2e/tests/csv-import.spec.ts
+++ b/e2e/tests/csv-import.spec.ts
@@ -24,4 +24,15 @@ test.describe("CSV import", () => {
     await expect(await geoPage.historyCount()).toBe(15);
     await expect(page.locator("#history-list .history-header")).toHaveCount(15);
   });
+
+  test("should show manual column mapping for custom csv", async ({ page }) => {
+    const geoPage = new GeoConvertPage(page);
+    const csvPath = "./examples/custom_sample.csv";
+
+    await geoPage.goto();
+    await geoPage.uploadCSV(csvPath);
+    await geoPage.selectCoordinateType("WGS84");
+
+    await expect(await geoPage.isManualMappingVisible()).toBe(true);
+  });
 });

--- a/e2e/tests/pageObjects/GeoConvertPage.ts
+++ b/e2e/tests/pageObjects/GeoConvertPage.ts
@@ -41,6 +41,15 @@ export class GeoConvertPage {
     await this.page.click("#confirm-csv-import");
   }
 
+  async selectCoordinateType(type: "UTM" | "WGS84"): Promise<void> {
+    const selector = `input[name="coordinate-type"][value="${type}"]`;
+    await this.page.check(selector);
+  }
+
+  async isManualMappingVisible(): Promise<boolean> {
+    return this.page.isVisible("#manual-column-mapping");
+  }
+
   async downloadCSV(): Promise<{ path: string; filename: string }> {
     // Wait for the CSV download modal to appear
     await this.page.waitForSelector("#confirm-csv-download", { timeout: 5000 });


### PR DESCRIPTION
## Summary
- expand `GeoConvertPage` page object with helpers for selecting coordinate type and visibility check for manual mapping
- test manual column mapping prompt when a custom CSV is uploaded

## Testing
- `pnpm --dir geo-convert test`
- `pnpm --dir geo-convert build`
- `pnpm --dir e2e e2e --grep "manual column"` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff978be88332a4be3e5de17ec624