### PR TITLE
Add failing conversion title e2e test

### DIFF
--- a/e2e/tests/csv-import.spec.ts
+++ b/e2e/tests/csv-import.spec.ts
@@ -11,11 +11,15 @@ test.describe("CSV import", () => {
     const csvPath = "./examples/sample.csv";
 
     await geoPage.goto();
+    const conversionTitle = "My Custom Conversion";
+    await geoPage.enterConversionTitle(conversionTitle);
     await geoPage.uploadCSV(csvPath);
     await geoPage.confirmCSVImport();
 
     // Download the converted file and validate as snapshot
     const downloadResult = await geoPage.downloadCSV();
+
+    await expect(downloadResult.filename).toBe(`${conversionTitle}.csv`);
 
     const fileContent = await readFile(downloadResult.path, "utf-8");
 

--- a/e2e/tests/pageObjects/GeoConvertPage.ts
+++ b/e2e/tests/pageObjects/GeoConvertPage.ts
@@ -20,6 +20,10 @@ export class GeoConvertPage {
     await this.page.click("#convert-to-utm");
   }
 
+  async enterConversionTitle(title: string): Promise<void> {
+    await this.page.fill("#conversion-title", title);
+  }
+
   async getUTMValues(): Promise<{
     zone: string;
     hemisphere: string;


### PR DESCRIPTION
## Summary
- extend GeoConvertPage page object with `enterConversionTitle`
- update csv-import test to fill a title and expect the downloaded file name to match

## Testing
- `pnpm test` inside geo-convert package
- `pnpm build` inside geo-convert package
- `pnpm e2e` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb270d3883328ed26ef341b67fd3