### PR TITLE
Add dark mode toggle

### DIFF
--- a/geo-convert/src/components/themeToggle/index.ts
+++ b/geo-convert/src/components/themeToggle/index.ts
@@ -1,0 +1,2 @@
+export { createThemeToggle } from "./themeToggle";
+export type { Theme } from "./types";

--- a/geo-convert/src/components/themeToggle/themeToggle.spec.ts
+++ b/geo-convert/src/components/themeToggle/themeToggle.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createThemeToggle, applyTheme } from "./themeToggle";
+
+describe("createThemeToggle", () => {
+  let button: HTMLButtonElement;
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+    button = createThemeToggle();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.className = "";
+  });
+
+  it("should create a button element", () => {
+    expect(button.tagName).toBe("BUTTON");
+    expect(button.id).toBe("theme-toggle");
+  });
+
+  it("should toggle theme class on click", () => {
+    document.body.appendChild(button);
+
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+    button.click();
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    button.click();
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+  });
+});
+
+describe("applyTheme", () => {
+  afterEach(() => {
+    document.documentElement.className = "";
+  });
+
+  it("should apply light theme", () => {
+    applyTheme("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+  });
+
+  it("should apply dark theme", () => {
+    document.documentElement.classList.add("light");
+    applyTheme("dark");
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+  });
+});

--- a/geo-convert/src/components/themeToggle/themeToggle.ts
+++ b/geo-convert/src/components/themeToggle/themeToggle.ts
@@ -1,0 +1,77 @@
+import type { Theme } from "./types";
+
+/**
+ * Apply the given theme to the document
+ */
+export const applyTheme = (theme: Theme): void => {
+  const html = document.documentElement;
+
+  if (theme === "light") {
+    html.classList.add("light");
+    return;
+  }
+
+  html.classList.remove("light");
+};
+
+/**
+ * Load the saved theme preference or fall back to system preference
+ */
+export const loadTheme = (): Theme => {
+  const stored = localStorage.getItem("geo-convert-theme");
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+  if (typeof window.matchMedia !== "function") {
+    return "dark";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+};
+
+/**
+ * Persist the theme preference
+ */
+export const saveTheme = (theme: Theme): void => {
+  try {
+    localStorage.setItem("geo-convert-theme", theme);
+  } catch (error) {
+    console.warn("Failed to save theme:", error);
+  }
+};
+
+/**
+ * Creates a dark mode toggle button
+ */
+export const createThemeToggle = (): HTMLButtonElement => {
+  const button = document.createElement("button");
+  button.id = "theme-toggle";
+  button.className =
+    "bg-white/10 border border-white/20 rounded px-3 py-2 text-white text-sm h-full flex items-center justify-center hover:bg-white/15 hover:border-white/30 transition-all duration-200";
+  button.title = "Toggle theme";
+
+  const icon = document.createElement("i");
+  button.appendChild(icon);
+
+  const setIcon = (theme: Theme): void => {
+    icon.dataset.lucide = theme === "light" ? "moon" : "sun";
+  };
+
+  const initial = loadTheme();
+  applyTheme(initial);
+  setIcon(initial);
+
+  button.addEventListener("click", () => {
+    const nextTheme = document.documentElement.classList.contains("light")
+      ? "dark"
+      : "light";
+
+    applyTheme(nextTheme);
+    saveTheme(nextTheme);
+    setIcon(nextTheme);
+  });
+
+  return button;
+};

--- a/geo-convert/src/components/themeToggle/types.ts
+++ b/geo-convert/src/components/themeToggle/types.ts
@@ -1,0 +1,1 @@
+export type Theme = "light" | "dark";

--- a/geo-convert/src/main.ts
+++ b/geo-convert/src/main.ts
@@ -6,10 +6,20 @@ import {
   parseCSV,
   parseExcel,
 } from "./converters";
-import { createIcons, Pencil, Trash2, Upload, Info, Sheet } from "lucide";
+import {
+  createIcons,
+  Pencil,
+  Trash2,
+  Upload,
+  Info,
+  Sheet,
+  Sun,
+  Moon,
+} from "lucide";
 import { generateId } from "./utils/generateId";
 import { initI18n, changeLanguage, t, getCurrentLanguage } from "./i18n";
 import { createInfoButton } from "./components/infoButton";
+import { createThemeToggle } from "./components/themeToggle";
 import { Notyf } from "notyf";
 import "notyf/notyf.min.css";
 import type {
@@ -29,6 +39,7 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
         <h1 class="mb-0 flex-shrink-0 leading-none text-4xl text-white" data-i18n="title">Geographic Coordinate Converter</h1>
       </div>
       <div class="flex items-center gap-2 flex-shrink-0 h-[2.5rem]">
+        <div id="theme-toggle-container"></div>
         <select id="language-select" class="bg-white/10 border border-white/20 rounded px-3 py-2 text-white text-sm h-full">
           <option value="he">עברית</option>
           <option value="en">English</option>
@@ -164,6 +175,13 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
   </div>
 `;
 
+// Create and insert the theme toggle and info button
+const themeToggleContainer = document.querySelector<HTMLDivElement>(
+  "#theme-toggle-container"
+)!;
+const themeToggle = createThemeToggle();
+themeToggleContainer.appendChild(themeToggle);
+
 // Create and insert the info button
 const infoButtonContainer = document.querySelector<HTMLDivElement>(
   "#info-button-container"
@@ -171,7 +189,7 @@ const infoButtonContainer = document.querySelector<HTMLDivElement>(
 const infoButton = createInfoButton();
 infoButtonContainer.appendChild(infoButton);
 
-createIcons({ icons: { Pencil, Trash2, Upload, Info, Sheet } });
+createIcons({ icons: { Pencil, Trash2, Upload, Info, Sheet, Sun, Moon } });
 
 // Initialize Notyf for toast notifications
 const notyf = new Notyf({

--- a/geo-convert/src/style.css
+++ b/geo-convert/src/style.css
@@ -832,6 +832,20 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+html.light {
+  color: #213547;
+  background-color: #ffffff;
+  color-scheme: light;
+}
+
+html.light a:hover {
+  color: #747bff;
+}
+
+html.light button {
+  background-color: #f9f9f9;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;


### PR DESCRIPTION
## Summary
- implement theme toggle component with tests
- add light theme CSS rules
- show toggle next to language selector

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a120ddde88332a012f1bf7264bf62