### PR TITLE
Fix light mode color scheme

### DIFF
--- a/geo-convert/src/style.css
+++ b/geo-convert/src/style.css
@@ -22,7 +22,7 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: dark;
+  color-scheme: light;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
- correct the CSS `color-scheme` for light mode

## Testing
- `pnpm test` *(fails: ReferenceError: window is not defined)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a5f501b048332922f872505e5e64f